### PR TITLE
feat: remove descriptions

### DIFF
--- a/data/datasets/flu_h1n1pdm_ha/dataset.json
+++ b/data/datasets/flu_h1n1pdm_ha/dataset.json
@@ -1,6 +1,5 @@
 {
   "defaultRef": "CY121680",
-  "description": "Influenza A H1N1pdm, HA segment",
   "enabled": true,
   "metadata": {},
   "name": "flu_h1n1pdm_ha",

--- a/data/datasets/flu_h3n2_ha/dataset.json
+++ b/data/datasets/flu_h3n2_ha/dataset.json
@@ -1,6 +1,5 @@
 {
   "defaultRef": "CY163680",
-  "description": "Influenza A H3N2, HA segment",
   "enabled": true,
   "metadata": {},
   "name": "flu_h3n2_ha",

--- a/data/datasets/flu_vic_ha/dataset.json
+++ b/data/datasets/flu_vic_ha/dataset.json
@@ -1,6 +1,5 @@
 {
   "defaultRef": "KX058884",
-  "description": "Influenza B Victoria, HA segment",
   "enabled": true,
   "metadata": {},
   "name": "flu_vic_ha",

--- a/data/datasets/flu_yam_ha/dataset.json
+++ b/data/datasets/flu_yam_ha/dataset.json
@@ -1,6 +1,5 @@
 {
   "defaultRef": "JN993010",
-  "description": "Influenza B Yamagata, HA segment",
   "enabled": true,
   "metadata": {},
   "name": "flu_yam_ha",

--- a/data/datasets/sars-cov-2/dataset.json
+++ b/data/datasets/sars-cov-2/dataset.json
@@ -1,6 +1,5 @@
 {
   "defaultRef": "MN908947",
-  "description": "Severe acute respiratory syndrome coronavirus 2, the virus that causes COVID-19",
   "enabled": true,
   "metadata": {},
   "name": "sars-cov-2",


### PR DESCRIPTION
This removes the "description" field in the datasets. Maintaining this seems to be just an additional work that we don't need. Adding it later is easier than removing.

Corresponding PR in software: https://github.com/nextstrain/nextclade/pull/526
