### PR TITLE
feat: add default genes

### DIFF
--- a/data/datasets/flu_h1n1pdm_ha/dataset.json
+++ b/data/datasets/flu_h1n1pdm_ha/dataset.json
@@ -1,4 +1,5 @@
 {
+  "defaultGene": "HA1",
   "defaultRef": "CY121680",
   "enabled": true,
   "metadata": {},

--- a/data/datasets/flu_h1n1pdm_ha/dataset.json
+++ b/data/datasets/flu_h1n1pdm_ha/dataset.json
@@ -2,6 +2,7 @@
   "defaultGene": "HA1",
   "defaultRef": "CY121680",
   "enabled": true,
+  "geneOrderPreference": ["HA1", "HA2"],
   "metadata": {},
   "name": "flu_h1n1pdm_ha",
   "nameFriendly": "Influenza A H1N1pdm HA"

--- a/data/datasets/flu_h3n2_ha/dataset.json
+++ b/data/datasets/flu_h3n2_ha/dataset.json
@@ -2,6 +2,7 @@
   "defaultGene": "HA1",
   "defaultRef": "CY163680",
   "enabled": true,
+  "geneOrderPreference": ["HA1", "HA2"],
   "metadata": {},
   "name": "flu_h3n2_ha",
   "nameFriendly": "Influenza A H3N2 HA"

--- a/data/datasets/flu_h3n2_ha/dataset.json
+++ b/data/datasets/flu_h3n2_ha/dataset.json
@@ -1,4 +1,5 @@
 {
+  "defaultGene": "HA1",
   "defaultRef": "CY163680",
   "enabled": true,
   "metadata": {},

--- a/data/datasets/flu_vic_ha/dataset.json
+++ b/data/datasets/flu_vic_ha/dataset.json
@@ -2,6 +2,7 @@
   "defaultGene": "HA1",
   "defaultRef": "KX058884",
   "enabled": true,
+  "geneOrderPreference": ["HA1", "HA2"],
   "metadata": {},
   "name": "flu_vic_ha",
   "nameFriendly": "Influenza B Victoria HA"

--- a/data/datasets/flu_vic_ha/dataset.json
+++ b/data/datasets/flu_vic_ha/dataset.json
@@ -1,4 +1,5 @@
 {
+  "defaultGene": "HA1",
   "defaultRef": "KX058884",
   "enabled": true,
   "metadata": {},

--- a/data/datasets/flu_yam_ha/dataset.json
+++ b/data/datasets/flu_yam_ha/dataset.json
@@ -1,4 +1,5 @@
 {
+  "defaultGene": "HA1",
   "defaultRef": "JN993010",
   "enabled": true,
   "metadata": {},

--- a/data/datasets/flu_yam_ha/dataset.json
+++ b/data/datasets/flu_yam_ha/dataset.json
@@ -2,6 +2,7 @@
   "defaultGene": "HA1",
   "defaultRef": "JN993010",
   "enabled": true,
+  "geneOrderPreference": ["HA1", "HA2"],
   "metadata": {},
   "name": "flu_yam_ha",
   "nameFriendly": "Influenza B Yamagata HA"

--- a/data/datasets/sars-cov-2/dataset.json
+++ b/data/datasets/sars-cov-2/dataset.json
@@ -1,4 +1,5 @@
 {
+  "defaultGene": "S",
   "defaultRef": "MN908947",
   "enabled": true,
   "metadata": {},

--- a/data/datasets/sars-cov-2/dataset.json
+++ b/data/datasets/sars-cov-2/dataset.json
@@ -2,6 +2,20 @@
   "defaultGene": "S",
   "defaultRef": "MN908947",
   "enabled": true,
+  "geneOrderPreference": [
+    "S",
+    "ORF1a",
+    "ORF1b",
+    "ORF3a",
+    "ORF6",
+    "ORF7a",
+    "ORF7b",
+    "ORF8",
+    "ORF9b",
+    "E",
+    "M",
+    "N"
+  ],
   "metadata": {},
   "name": "sars-cov-2",
   "nameFriendly": "SARS-CoV-2"


### PR DESCRIPTION
Introduces the `defaultGene` and `geneOrderPreference` properties on datasets.

This helps to prioritize one genes compared to others and to better sort various lists in when displaying things in Nextclade.
