### PR TITLE
fix: emit correct tag into output tag.json files (alternative PR)

### DIFF
--- a/scripts/rebuild
+++ b/scripts/rebuild
@@ -139,41 +139,42 @@ if __name__ == '__main__':
             dataset_ref_dir = os.path.dirname(dataset_ref_json_path)
 
             # Read data descriptions for the tags
-            versions: List[dict] = []
+            version_jsons: List[dict] = []
             for tag_path in find_files("tag.json", dataset_ref_dir):
                 with open(tag_path, 'r') as f:
                     version_json: dict = json.load(f)
-                versions.append(version_json)
+                version_jsons.append(version_json)
 
-            versions.sort(key=lambda x: x["tag"], reverse=True)
+            del version_json
+            version_jsons.sort(key=lambda x: x["tag"], reverse=True)
 
-            for i, version in enumerate(versions):
-                tag = version["tag"]
-                paths = get_paths(dataset_json, dataset_ref_json, version)
+            for i, version_json in enumerate(version_jsons):
+                tag = version_json["tag"]
+                paths = get_paths(dataset_json, dataset_ref_json, version_json)
 
                 # Generate `tag.json` inside output directory
-                tag_metadata = {**version["metadata"], **dataset_json["metadata"], **dataset_ref_json["metadata"]}
-                tag_json = {**version, **dataset_json, **dataset_ref_json, "metadata": tag_metadata}
+                tag_metadata = {**version_json["metadata"], **dataset_json["metadata"], **dataset_ref_json["metadata"]}
+                tag_json = {**version_json, **dataset_json, **dataset_ref_json, "metadata": tag_metadata}
                 tag_json_path = os.path.join(paths.output_files_dir_abs, "tag.json")
                 json_write(tag_json, tag_json_path)
 
                 # Copy files, including `tag.json` into output directory
-                copy_dataset_version_files(version, src_dir=paths.input_files_dir_abs,
+                copy_dataset_version_files(version_json, src_dir=paths.input_files_dir_abs,
                                            dst_dir=paths.output_files_dir_abs)
 
                 # Zip output directory
-                make_zip_bundle(dataset_json, dataset_ref_json, version)
+                make_zip_bundle(dataset_json, dataset_ref_json, version_json)
 
                 # Copy latest version output directory to directory `latest`
-                # (assumes `versions` are sorted by tag, reversed!)
+                # (assumes `version_jsons` are sorted by tag, reversed!)
                 if i == 0:
                     this_version_dir = os.path.join(DATA_OUTPUT_DIR, paths.versions_dir, tag)
                     latest_version_dir = os.path.join(DATA_OUTPUT_DIR, paths.versions_dir, "latest")
                     shutil.copytree(this_version_dir, latest_version_dir)
 
-                version.update({"files": paths.files, "zipBundle": paths.zip_bundle_url, "latest": i == 0})
+                version_json.update({"files": paths.files, "zipBundle": paths.zip_bundle_url, "latest": i == 0})
 
-            dataset_refs.append({**dataset_ref_json, "versions": versions})
+            dataset_refs.append({**dataset_ref_json, "version_jsons": version_jsons})
 
         dataset = {**dataset_json, "datasetRefs": dataset_refs}
         datasets.append(dataset)


### PR DESCRIPTION
# Description of proposed changes

The variable version_json was used in the loop body. It comes from an unrelated scope before the loop And it contains the last read version_json. Instead we need the version, that the loop is iterated on. This caused the unrelated data to be emitted into tag.json.

This commit renames versions -> version_json and version -> version_json, it also deletes the version_json that is still hanging around to prevent this bug from ever happening again even if code is changed.

# Related issue(s)

Resolves nextstrain/nextclade#572

# Testing

The file data_output/datasets/sars-cov-2/references/MN908947/versions/2021-10-11T19:00:32Z/files/tag.json
now contains correct tag.