### PR TITLE
feat: remove qc weights for deletions

### DIFF
--- a/data/datasets/sars-cov-2/references/MN908947/versions/2022-01-18T12:00:00Z/files/qc.json
+++ b/data/datasets/sars-cov-2/references/MN908947/versions/2022-01-18T12:00:00Z/files/qc.json
@@ -5,11 +5,8 @@
     "typical": 8,
     "cutoff": 24,
     "weightLabeledSubstitutions": 4,
-    "weightLabeledDeletions": 4,
     "weightReversionSubstitutions": 6,
-    "weightReversionDeletions": 8,
-    "weightUnlabeledSubstitutions": 1,
-    "weightUnlabeledDeletions": 1
+    "weightUnlabeledSubstitutions": 1
   },
   "missingData": {
     "enabled": true,


### PR DESCRIPTION
In Nextclade, we decided against splitting private deletions for now and only do this for substitutions. So the deletion weights are not used anywhere. Let's remove them to avoid confusion. [Slack thread](https://neherlab.slack.com/archives/C015PFP5V44/p1642673286092400?thread_ts=1642673073.091600&cid=C015PFP5V44)
