### PR TITLE
chore(infea): add missing callback invocation for lambda@edge function

### DIFF
--- a/infra/rewriteToGzip.lambda.js
+++ b/infra/rewriteToGzip.lambda.js
@@ -11,4 +11,6 @@ exports.handler = (event, context, callback) => {
     request.uri += '.gz'
     callback(null, request)
   }
+
+  callback(null, request)
 }


### PR DESCRIPTION
This function conditionally rewrites non-gz URLs to gz. The zip files are conditionally excluded. However, in case o zip file the "done" callback was not called at the end of the function, so the response was incorrect.

Here I add the callback invocation at the end of the function, so that requests for zip files are correctly replied to.

I deployd the new function to all 3 environments

Test:

```bash
curl -fsSLOJ https://data.clades.nextstrain.org/datasets/sars-cov-2/references/MN908947/versions/2022-02-07T12:00:00Z/zip-bundle/nextclade_dataset_sars-cov-2_MN908947_2022-02-07T12:00:00Z.zip

unzip nextclade_dataset_sars-cov-2_MN908947_2022-02-07T12:00:00Z.zip
```


