### PR TITLE
chore(infra): remove extra callback invocation in lambda

### DIFF
--- a/infra/rewriteToGzip.lambda.js
+++ b/infra/rewriteToGzip.lambda.js
@@ -9,7 +9,6 @@ exports.handler = (event, context, callback) => {
   // Here we rewrite the URL to get the corresponding .gz files.
   if(!request.uri.endsWith('.zip')) {
     request.uri += '.gz'
-    callback(null, request)
   }
 
   callback(null, request)


### PR DESCRIPTION
Followup of https://github.com/nextstrain/nextclade_data/pull/24

After https://github.com/nextstrain/nextclade_data/pull/24 there were 2 callback invocations for the base on non-zip files. This removes the redundant call.


