### PR TITLE
fix: remove mpx datasets from index v1

### DIFF
--- a/scripts/rebuild
+++ b/scripts/rebuild
@@ -126,6 +126,9 @@ position = {
 position = defaultdict(int, position)
 
 def postprocess_datasets_v1(datasets, settings):
+    # mpx datasets are not compatible with v1
+    # TODO: should probably filter by version instead, but it is a bit more involved due to nested dict structure
+    datasets = list(filter(lambda dataset: "mpx" not in dataset["name"].lower(), datasets))
 
     # Sort datasets alphabetically
     datasets.sort(key=lambda x: x["nameFriendly"],reverse=True)


### PR DESCRIPTION
This removes monkeypox (mpx) datasets from index json v1. 

Version strings in `version.compatibility.nextcladeCli.min` in these datasets crash semver parser in Nextclade v1. Also Nextclade v1 cannot process monkeypox sequences anyways, so there is not much use listing them.
