### PR TITLE
fix: identify datasets uniquely

### DIFF
--- a/scripts/rebuild
+++ b/scripts/rebuild
@@ -206,6 +206,8 @@ def postprocess_datasets_v2(datasets_v2, _):
     datasets_v2.sort(key=lambda x: position[x["attributes"]["name"]["value"]], reverse=True)
     datasets_v2.sort(key=lambda x: x["attributes"]["name"]["value"] == "sars-cov-2", reverse=True)
 
+    datasets_v2 = [ { "id": str(i), **dataset } for i, dataset in enumerate(datasets_v2) ]
+
     index_json = dict()
     index_json.update({"schema": "2.0.0"})
     index_json.update({"datasets": datasets_v2})


### PR DESCRIPTION
This modifies index v2 JSON - adds a `.datasets[].id`which is a string what identifies the dataset uniquely (within a given deployment).

This serves as a key to tell datasets apart in Nextclade Web. The sister PR is here: https://github.com/nextstrain/nextclade/pull/1062
