### PR TITLE
fix: typo in default ref name for flu_h1n1pdm_na MW626056

### DIFF
--- a/data/datasets/flu_h1n1pdm_na/dataset.json
+++ b/data/datasets/flu_h1n1pdm_na/dataset.json
@@ -1,6 +1,6 @@
 {
   "defaultGene": "NA",
-  "defaultRef": "MW626066",
+  "defaultRef": "MW626056",
   "enabled": true,
   "geneOrderPreference": ["NA"],
   "metadata": {},


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade_data/issues/69 (nice!)

The flu_h1n1pdm_na dataset has only one reference MW626056, but it's not set as default, due to a typo in the config file.

Here I fix the typo and it should fix the error reported in  https://github.com/nextstrain/nextclade_data/issues/69
