### PR TITLE
Add alignmentParams for SC2, MPXV, RSV datasets

### DIFF
--- a/data/nextstrain/MPXV/ancestral/pathogen.json
+++ b/data/nextstrain/MPXV/ancestral/pathogen.json
@@ -1,10 +1,11 @@
 {
   "alignmentParams": {
-    "excess_bandwidth": 20,
-    "gap_alignment_side": "left",
-    "max_indel": 20000,
-    "seed_spacing": 500,
-    "terminal_bandwidth": 500
+    "excessBandwidth": 100,
+    "terminalBandwidth": 300,
+    "allowedMismatches": 8,
+    "windowSize": 40,
+    "minSeedCover": 0.1,
+    "gapAlignmentSide": "left"
   },
   "attributes": {
     "name": {

--- a/data/nextstrain/MPXV/ancestral/pathogen.json
+++ b/data/nextstrain/MPXV/ancestral/pathogen.json
@@ -1,11 +1,11 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 100,
-    "terminalBandwidth": 300,
-    "allowedMismatches": 8,
-    "windowSize": 40,
-    "minSeedCover": 0.1,
-    "gapAlignmentSide": "left"
+    "excess_bandwidth": 100,
+    "terminal_bandwidth": 300,
+    "allowed_mismatches": 8,
+    "window_size": 40,
+    "min_seed_cover": 0.1,
+    "gap_alignment_side": "left"
   },
   "attributes": {
     "name": {

--- a/data/nextstrain/hMPXV/NC_063383.1/pathogen.json
+++ b/data/nextstrain/hMPXV/NC_063383.1/pathogen.json
@@ -1,11 +1,11 @@
 {
   "alignmentParams": {
-    "allowedMismatches": 5,
-    "excessBandwidth": 40,
-    "gapAlignmentSide": "left",
-    "minSeedCover": 0.1,
-    "terminalBandwidth": 200,
-    "windowSize": 30
+    "allowed_mismatches": 5,
+    "excess_bandwidth": 40,
+    "gap_alignment_side": "left",
+    "min_seed_cover": 0.1,
+    "terminal_bandwidth": 200,
+    "window_size": 30
   },
   "attributes": {
     "name": {

--- a/data/nextstrain/hMPXV/NC_063383.1/pathogen.json
+++ b/data/nextstrain/hMPXV/NC_063383.1/pathogen.json
@@ -1,10 +1,11 @@
 {
   "alignmentParams": {
-    "excess_bandwidth": 20,
-    "gap_alignment_side": "left",
-    "max_indel": 20000,
-    "seed_spacing": 500,
-    "terminal_bandwidth": 500
+    "allowedMismatches": 5,
+    "excessBandwidth": 40,
+    "gapAlignmentSide": "left",
+    "minSeedCover": 0.1,
+    "terminalBandwidth": 200,
+    "windowSize": 30
   },
   "attributes": {
     "name": {

--- a/data/nextstrain/hMPXV_B1/pseudo_ON563414/pathogen.json
+++ b/data/nextstrain/hMPXV_B1/pseudo_ON563414/pathogen.json
@@ -1,10 +1,11 @@
 {
   "alignmentParams": {
-    "excess_bandwidth": 20,
-    "gap_alignment_side": "left",
-    "max_indel": 20000,
-    "seed_spacing": 500,
-    "terminal_bandwidth": 500
+    "excessBandwidth": 40,
+    "terminalBandwidth": 200,
+    "allowedMismatches": 5,
+    "windowSize": 30,
+    "minSeedCover": 0.1,
+    "gapAlignmentSide": "left"
   },
   "attributes": {
     "name": {

--- a/data/nextstrain/hMPXV_B1/pseudo_ON563414/pathogen.json
+++ b/data/nextstrain/hMPXV_B1/pseudo_ON563414/pathogen.json
@@ -1,11 +1,11 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 40,
-    "terminalBandwidth": 200,
-    "allowedMismatches": 5,
-    "windowSize": 30,
-    "minSeedCover": 0.1,
-    "gapAlignmentSide": "left"
+    "excess_bandwidth": 40,
+    "terminal_bandwidth": 200,
+    "allowed_mismatches": 5,
+    "window_size": 30,
+    "min_seed_cover": 0.1,
+    "gap_alignment_side": "left"
   },
   "attributes": {
     "name": {

--- a/data/nextstrain/rsv_a/EPI_ISL_412866/pathogen.json
+++ b/data/nextstrain/rsv_a/EPI_ISL_412866/pathogen.json
@@ -1,13 +1,13 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 30,
-    "terminalBandwidth": 100,
-    "allowedMismatches": 4,
-    "windowSize": 15,
-    "minMatchLength": 30,
-    "minSeedCover": 0.05,
-    "gapAlignmentSide": "left",
-    "kmerDistance": 10
+    "excess_bandwidth": 30,
+    "terminal_bandwidth": 100,
+    "allowed_mismatches": 4,
+    "window_size": 15,
+    "min_match_length": 30,
+    "min_seed_cover": 0.05,
+    "gap_alignment_side": "left",
+    "kmer_distance": 10
   },
   "attributes": {
     "name": {

--- a/data/nextstrain/rsv_a/EPI_ISL_412866/pathogen.json
+++ b/data/nextstrain/rsv_a/EPI_ISL_412866/pathogen.json
@@ -1,4 +1,14 @@
 {
+  "alignmentParams": {
+    "excessBandwidth": 30,
+    "terminalBandwidth": 100,
+    "allowedMismatches": 4,
+    "windowSize": 15,
+    "minMatchLength": 30,
+    "minSeedCover": 0.05,
+    "gapAlignmentSide": "left",
+    "kmerDistance": 10
+  },
   "attributes": {
     "name": {
       "value": "rsv_a",

--- a/data/nextstrain/rsv_b/EPI_ISL_1653999/pathogen.json
+++ b/data/nextstrain/rsv_b/EPI_ISL_1653999/pathogen.json
@@ -1,4 +1,14 @@
 {
+  "alignmentParams": {
+    "excessBandwidth": 40,
+    "terminalBandwidth": 100,
+    "allowedMismatches": 4,
+    "windowSize": 15,
+    "minMatchLength": 30,
+    "minSeedCover": 0.05,
+    "gapAlignmentSide": "left",
+    "kmerDistance": 10
+  },
   "attributes": {
     "name": {
       "value": "rsv_b",

--- a/data/nextstrain/rsv_b/EPI_ISL_1653999/pathogen.json
+++ b/data/nextstrain/rsv_b/EPI_ISL_1653999/pathogen.json
@@ -1,13 +1,13 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 40,
-    "terminalBandwidth": 100,
-    "allowedMismatches": 4,
-    "windowSize": 15,
-    "minMatchLength": 30,
-    "minSeedCover": 0.05,
-    "gapAlignmentSide": "left",
-    "kmerDistance": 10
+    "excess_bandwidth": 40,
+    "terminal_bandwidth": 100,
+    "allowed_mismatches": 4,
+    "window_size": 15,
+    "min_match_length": 30,
+    "min_seed_cover": 0.05,
+    "gap_alignment_side": "left",
+    "kmer_distance": 10
   },
   "attributes": {
     "name": {

--- a/data/nextstrain/sars-cov-2-21L/BA.2/pathogen.json
+++ b/data/nextstrain/sars-cov-2-21L/BA.2/pathogen.json
@@ -1,10 +1,10 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 9,
-    "terminalBandwidth": 100,
-    "allowedMismatches": 4,
-    "gapAlignmentSide": "right",
-    "minSeedCover": 0.1
+    "excess_bandwidth": 9,
+    "terminal_bandwidth": 100,
+    "allowed_mismatches": 4,
+    "gap_alignment_side": "right",
+    "min_seed_cover": 0.1
   },
   "attributes": {
     "name": {

--- a/data/nextstrain/sars-cov-2-21L/BA.2/pathogen.json
+++ b/data/nextstrain/sars-cov-2-21L/BA.2/pathogen.json
@@ -3,6 +3,7 @@
     "excessBandwidth": 9,
     "terminalBandwidth": 100,
     "allowedMismatches": 4,
+    "gapAlignmentSide": "right",
     "minSeedCover": 0.1
   },
   "attributes": {

--- a/data/nextstrain/sars-cov-2/MN908947/pathogen.json
+++ b/data/nextstrain/sars-cov-2/MN908947/pathogen.json
@@ -1,4 +1,11 @@
 {
+  "alignmentParams": {
+    "excessBandwidth": 9,
+    "terminalBandwidth": 100,
+    "allowedMismatches": 4,
+    "gapAlignmentSide": "right",
+    "minSeedCover": 0.1
+  },
   "attributes": {
     "name": {
       "value": "sars-cov-2",

--- a/data/nextstrain/sars-cov-2/MN908947/pathogen.json
+++ b/data/nextstrain/sars-cov-2/MN908947/pathogen.json
@@ -1,10 +1,10 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 9,
-    "terminalBandwidth": 100,
-    "allowedMismatches": 4,
-    "gapAlignmentSide": "right",
-    "minSeedCover": 0.1
+    "excess_bandwidth": 9,
+    "terminal_bandwidth": 100,
+    "allowed_mismatches": 4,
+    "gap_alignment_side": "right",
+    "min_seed_cover": 0.1
   },
   "attributes": {
     "name": {

--- a/data_output/index.json
+++ b/data_output/index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "3.0.0",
-  "updatedAt": "2023-09-05T14:36:15Z",
+  "updatedAt": "2023-09-05T15:47:26Z",
   "collections": [
     {
       "meta": {

--- a/data_output/index.json
+++ b/data_output/index.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "3.0.0",
-  "updatedAt": "2023-09-05T12:21:31Z",
+  "updatedAt": "2023-09-05T14:36:15Z",
   "collections": [
     {
       "meta": {

--- a/data_output/nextstrain/MPXV/ancestral/unreleased/pathogen.json
+++ b/data_output/nextstrain/MPXV/ancestral/unreleased/pathogen.json
@@ -1,10 +1,11 @@
 {
   "alignmentParams": {
-    "excess_bandwidth": 20,
-    "gap_alignment_side": "left",
-    "max_indel": 20000,
-    "seed_spacing": 500,
-    "terminal_bandwidth": 500
+    "excessBandwidth": 100,
+    "terminalBandwidth": 300,
+    "allowedMismatches": 8,
+    "windowSize": 40,
+    "minSeedCover": 0.1,
+    "gapAlignmentSide": "left"
   },
   "attributes": {
     "name": {

--- a/data_output/nextstrain/MPXV/ancestral/unreleased/pathogen.json
+++ b/data_output/nextstrain/MPXV/ancestral/unreleased/pathogen.json
@@ -1,11 +1,11 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 100,
-    "terminalBandwidth": 300,
-    "allowedMismatches": 8,
-    "windowSize": 40,
-    "minSeedCover": 0.1,
-    "gapAlignmentSide": "left"
+    "excess_bandwidth": 100,
+    "terminal_bandwidth": 300,
+    "allowed_mismatches": 8,
+    "window_size": 40,
+    "min_seed_cover": 0.1,
+    "gap_alignment_side": "left"
   },
   "attributes": {
     "name": {

--- a/data_output/nextstrain/hMPXV/NC_063383.1/unreleased/pathogen.json
+++ b/data_output/nextstrain/hMPXV/NC_063383.1/unreleased/pathogen.json
@@ -1,11 +1,11 @@
 {
   "alignmentParams": {
-    "allowedMismatches": 5,
-    "excessBandwidth": 40,
-    "gapAlignmentSide": "left",
-    "minSeedCover": 0.1,
-    "terminalBandwidth": 200,
-    "windowSize": 30
+    "allowed_mismatches": 5,
+    "excess_bandwidth": 40,
+    "gap_alignment_side": "left",
+    "min_seed_cover": 0.1,
+    "terminal_bandwidth": 200,
+    "window_size": 30
   },
   "attributes": {
     "name": {

--- a/data_output/nextstrain/hMPXV/NC_063383.1/unreleased/pathogen.json
+++ b/data_output/nextstrain/hMPXV/NC_063383.1/unreleased/pathogen.json
@@ -1,10 +1,11 @@
 {
   "alignmentParams": {
-    "excess_bandwidth": 20,
-    "gap_alignment_side": "left",
-    "max_indel": 20000,
-    "seed_spacing": 500,
-    "terminal_bandwidth": 500
+    "allowedMismatches": 5,
+    "excessBandwidth": 40,
+    "gapAlignmentSide": "left",
+    "minSeedCover": 0.1,
+    "terminalBandwidth": 200,
+    "windowSize": 30
   },
   "attributes": {
     "name": {

--- a/data_output/nextstrain/hMPXV_B1/pseudo_ON563414/unreleased/pathogen.json
+++ b/data_output/nextstrain/hMPXV_B1/pseudo_ON563414/unreleased/pathogen.json
@@ -1,10 +1,11 @@
 {
   "alignmentParams": {
-    "excess_bandwidth": 20,
-    "gap_alignment_side": "left",
-    "max_indel": 20000,
-    "seed_spacing": 500,
-    "terminal_bandwidth": 500
+    "excessBandwidth": 40,
+    "terminalBandwidth": 200,
+    "allowedMismatches": 5,
+    "windowSize": 30,
+    "minSeedCover": 0.1,
+    "gapAlignmentSide": "left"
   },
   "attributes": {
     "name": {

--- a/data_output/nextstrain/hMPXV_B1/pseudo_ON563414/unreleased/pathogen.json
+++ b/data_output/nextstrain/hMPXV_B1/pseudo_ON563414/unreleased/pathogen.json
@@ -1,11 +1,11 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 40,
-    "terminalBandwidth": 200,
-    "allowedMismatches": 5,
-    "windowSize": 30,
-    "minSeedCover": 0.1,
-    "gapAlignmentSide": "left"
+    "excess_bandwidth": 40,
+    "terminal_bandwidth": 200,
+    "allowed_mismatches": 5,
+    "window_size": 30,
+    "min_seed_cover": 0.1,
+    "gap_alignment_side": "left"
   },
   "attributes": {
     "name": {

--- a/data_output/nextstrain/rsv_a/EPI_ISL_412866/unreleased/pathogen.json
+++ b/data_output/nextstrain/rsv_a/EPI_ISL_412866/unreleased/pathogen.json
@@ -1,13 +1,13 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 30,
-    "terminalBandwidth": 100,
-    "allowedMismatches": 4,
-    "windowSize": 15,
-    "minMatchLength": 30,
-    "minSeedCover": 0.05,
-    "gapAlignmentSide": "left",
-    "kmerDistance": 10
+    "excess_bandwidth": 30,
+    "terminal_bandwidth": 100,
+    "allowed_mismatches": 4,
+    "window_size": 15,
+    "min_match_length": 30,
+    "min_seed_cover": 0.05,
+    "gap_alignment_side": "left",
+    "kmer_distance": 10
   },
   "attributes": {
     "name": {

--- a/data_output/nextstrain/rsv_a/EPI_ISL_412866/unreleased/pathogen.json
+++ b/data_output/nextstrain/rsv_a/EPI_ISL_412866/unreleased/pathogen.json
@@ -1,4 +1,14 @@
 {
+  "alignmentParams": {
+    "excessBandwidth": 30,
+    "terminalBandwidth": 100,
+    "allowedMismatches": 4,
+    "windowSize": 15,
+    "minMatchLength": 30,
+    "minSeedCover": 0.05,
+    "gapAlignmentSide": "left",
+    "kmerDistance": 10
+  },
   "attributes": {
     "name": {
       "value": "rsv_a",

--- a/data_output/nextstrain/rsv_b/EPI_ISL_1653999/unreleased/pathogen.json
+++ b/data_output/nextstrain/rsv_b/EPI_ISL_1653999/unreleased/pathogen.json
@@ -1,4 +1,14 @@
 {
+  "alignmentParams": {
+    "excessBandwidth": 40,
+    "terminalBandwidth": 100,
+    "allowedMismatches": 4,
+    "windowSize": 15,
+    "minMatchLength": 30,
+    "minSeedCover": 0.05,
+    "gapAlignmentSide": "left",
+    "kmerDistance": 10
+  },
   "attributes": {
     "name": {
       "value": "rsv_b",

--- a/data_output/nextstrain/rsv_b/EPI_ISL_1653999/unreleased/pathogen.json
+++ b/data_output/nextstrain/rsv_b/EPI_ISL_1653999/unreleased/pathogen.json
@@ -1,13 +1,13 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 40,
-    "terminalBandwidth": 100,
-    "allowedMismatches": 4,
-    "windowSize": 15,
-    "minMatchLength": 30,
-    "minSeedCover": 0.05,
-    "gapAlignmentSide": "left",
-    "kmerDistance": 10
+    "excess_bandwidth": 40,
+    "terminal_bandwidth": 100,
+    "allowed_mismatches": 4,
+    "window_size": 15,
+    "min_match_length": 30,
+    "min_seed_cover": 0.05,
+    "gap_alignment_side": "left",
+    "kmer_distance": 10
   },
   "attributes": {
     "name": {

--- a/data_output/nextstrain/sars-cov-2-21L/BA.2/unreleased/pathogen.json
+++ b/data_output/nextstrain/sars-cov-2-21L/BA.2/unreleased/pathogen.json
@@ -1,10 +1,10 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 9,
-    "terminalBandwidth": 100,
-    "allowedMismatches": 4,
-    "gapAlignmentSide": "right",
-    "minSeedCover": 0.1
+    "excess_bandwidth": 9,
+    "terminal_bandwidth": 100,
+    "allowed_mismatches": 4,
+    "gap_alignment_side": "right",
+    "min_seed_cover": 0.1
   },
   "attributes": {
     "name": {

--- a/data_output/nextstrain/sars-cov-2-21L/BA.2/unreleased/pathogen.json
+++ b/data_output/nextstrain/sars-cov-2-21L/BA.2/unreleased/pathogen.json
@@ -3,6 +3,7 @@
     "excessBandwidth": 9,
     "terminalBandwidth": 100,
     "allowedMismatches": 4,
+    "gapAlignmentSide": "right",
     "minSeedCover": 0.1
   },
   "attributes": {

--- a/data_output/nextstrain/sars-cov-2/MN908947/unreleased/pathogen.json
+++ b/data_output/nextstrain/sars-cov-2/MN908947/unreleased/pathogen.json
@@ -1,4 +1,11 @@
 {
+  "alignmentParams": {
+    "excessBandwidth": 9,
+    "terminalBandwidth": 100,
+    "allowedMismatches": 4,
+    "gapAlignmentSide": "right",
+    "minSeedCover": 0.1
+  },
   "attributes": {
     "name": {
       "value": "sars-cov-2",

--- a/data_output/nextstrain/sars-cov-2/MN908947/unreleased/pathogen.json
+++ b/data_output/nextstrain/sars-cov-2/MN908947/unreleased/pathogen.json
@@ -1,10 +1,10 @@
 {
   "alignmentParams": {
-    "excessBandwidth": 9,
-    "terminalBandwidth": 100,
-    "allowedMismatches": 4,
-    "gapAlignmentSide": "right",
-    "minSeedCover": 0.1
+    "excess_bandwidth": 9,
+    "terminal_bandwidth": 100,
+    "allowed_mismatches": 4,
+    "gap_alignment_side": "right",
+    "min_seed_cover": 0.1
   },
   "attributes": {
     "name": {


### PR DESCRIPTION
Add somewhat optimized custom alignmentParams for SC2, MPXV, RSV datasets

Woops, this won't work, as we currently require kebab case for alignmentPairwiseParams