### PR TITLE
feat: remove updatedAt timestamp to avoid merge conflicts

### DIFF
--- a/data_output/index.json
+++ b/data_output/index.json
@@ -1,6 +1,5 @@
 {
   "schemaVersion": "3.0.0",
-  "updatedAt": "2023-09-06T13:34:06Z",
   "collections": [
     {
       "meta": {
@@ -2783,5 +2782,6 @@
         }
       ]
     }
-  ]
+  ],
+  "updatedAt": "2023-09-06T13:43:24Z"
 }

--- a/scripts/rebuild_v3
+++ b/scripts/rebuild_v3
@@ -181,7 +181,6 @@ def main():
 
   index_json = {
     "schemaVersion": "3.0.0",
-    "updatedAt": updated_at,
     "collections": collections,
   }
 


### PR DESCRIPTION
The `updatedAt` timestamp in the root of `index.json` causes constant merge conflicts between branches and PRs when updated by the rebuild bot. Let's remove it.

See: https://github.com/nextstrain/nextclade/pull/1246