### PR TITLE
Add glycosylation annotation to B/Yam results

### DIFF
--- a/data/nextstrain/flu/yam/ha/JN993010/CHANGELOG.md
+++ b/data/nextstrain/flu/yam/ha/JN993010/CHANGELOG.md
@@ -5,3 +5,5 @@ Initial release for Nextclade v3!
 This dataset is converted from the corresponding older dataset for Nextclade v2. You can find old versions of datasets here: https://github.com/nextstrain/nextclade_data/tree/2023-08-17--15-51-24--UTC/data/datasets
 
 Read more about Nextclade datasets in the documentation: https://docs.nextstrain.org/projects/nextclade/en/stable/user/datasets.html
+
+ - Adds glycosylation annotation to alignment results

--- a/data/nextstrain/flu/yam/ha/JN993010/pathogen.json
+++ b/data/nextstrain/flu/yam/ha/JN993010/pathogen.json
@@ -1,4 +1,29 @@
 {
+  "aaMotifs": [
+    {
+      "description": "N-linked glycosylation motifs (N-X-S/T with X any amino acid other than P)",
+      "includeGenes": [
+        {
+          "gene": "HA1"
+        },
+        {
+          "gene": "HA2",
+          "ranges": [
+            {
+              "begin": 0,
+              "end": 186
+            }
+          ]
+        }
+      ],
+      "motifs": [
+        "N[^P][ST]"
+      ],
+      "name": "glycosylation",
+      "nameFriendly": "Glycosylation",
+      "nameShort": "Glyc."
+    }
+  ],
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"

--- a/data_output/index.json
+++ b/data_output/index.json
@@ -767,6 +767,9 @@
               "mixedSites",
               "privateMutations",
               "stopCodons"
+            ],
+            "other": [
+              "aaMotifs"
             ]
           },
           "versions": [

--- a/data_output/nextstrain/flu/yam/ha/JN993010/unreleased/CHANGELOG.md
+++ b/data_output/nextstrain/flu/yam/ha/JN993010/unreleased/CHANGELOG.md
@@ -5,3 +5,5 @@ Initial release for Nextclade v3!
 This dataset is converted from the corresponding older dataset for Nextclade v2. You can find old versions of datasets here: https://github.com/nextstrain/nextclade_data/tree/2023-08-17--15-51-24--UTC/data/datasets
 
 Read more about Nextclade datasets in the documentation: https://docs.nextstrain.org/projects/nextclade/en/stable/user/datasets.html
+
+ - Adds glycosylation annotation to alignment results

--- a/data_output/nextstrain/flu/yam/ha/JN993010/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/yam/ha/JN993010/unreleased/pathogen.json
@@ -1,4 +1,29 @@
 {
+  "aaMotifs": [
+    {
+      "description": "N-linked glycosylation motifs (N-X-S/T with X any amino acid other than P)",
+      "includeGenes": [
+        {
+          "gene": "HA1"
+        },
+        {
+          "gene": "HA2",
+          "ranges": [
+            {
+              "begin": 0,
+              "end": 186
+            }
+          ]
+        }
+      ],
+      "motifs": [
+        "N[^P][ST]"
+      ],
+      "name": "glycosylation",
+      "nameFriendly": "Glycosylation",
+      "nameShort": "Glyc."
+    }
+  ],
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"


### PR DESCRIPTION
## Description of proposed changes

Adds the same amino acid motifs entry from the three other seasonal flu lineages to B/Yam, so users can see changes in glycosylation sites in Nextclade results. [The motif for B/Yam is the same as the motif for other lineages](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6328934/#sec3title). These annotations most likely did not get included in [the original addition of glycosylation sites](https://github.com/nextstrain/nextclade_data/pull/64) because we suspected Yam was already extinct. These annotations should be helpful for researchers performing retrospective analyses, though.

## Checklist

- [x] Checks pass