### PR TITLE
add script to rename defaultGene and geneOrderPreference

### DIFF
--- a/scripts/convert_v2_to_v3.py
+++ b/scripts/convert_v2_to_v3.py
@@ -10,6 +10,7 @@ from lib.changelog import format_dataset_attributes_md_table
 from lib.container import dict_set, dict_cleanup, dict_get, dict_remove_many
 from lib.date import now_iso
 from lib.fs import json_write, copy, json_read, file_write
+from migrate_002_default_gene import rename_default_gene
 
 
 def check_file(dataset_dir, filename):
@@ -139,6 +140,8 @@ def process_pathogen_json(tag_json, input_dir, output_dir):
     "reference",
     "tag",
   ])
+
+  pathogen_json = rename_default_gene(pathogen_json)
 
   pathogen_json = dict_cleanup(pathogen_json)
 

--- a/scripts/lib/container.py
+++ b/scripts/lib/container.py
@@ -1,6 +1,6 @@
 from collections import namedtuple, Counter
 from functools import reduce
-from typing import List, Iterable, TypeVar, Callable, Union
+from typing import List, Iterable, TypeVar, Callable, Union, Dict, Any
 
 T = TypeVar('T')
 
@@ -38,6 +38,26 @@ def dict_remove(obj: dict, key: str):
 def dict_remove_many(obj: dict, keys: List[str]):
   for key in keys:
     dict_remove(obj, key)
+
+
+def dict_rename_one_unordered_inplace(d: Dict[str, Any], old_key: str, new_key: str):
+  """
+  Rename one key. Do not preserve key order.
+  """
+  if old_key == new_key:
+    return
+
+  if old_key in d:
+    value = d.pop(old_key)
+    if value is not None:
+      d[new_key] = value
+
+
+def dict_rename_many(d: Dict[str, Any], replacements: Dict[str, str]):
+  """
+  Rename keys given a mapping dict. Slow for large dicts.
+  """
+  return {replacements.get(k, k): v for k, v in d.items()}
 
 
 def list_cleanup(data: List) -> List:

--- a/scripts/migrate_002_default_gene.py
+++ b/scripts/migrate_002_default_gene.py
@@ -1,0 +1,20 @@
+from lib.container import dict_rename_many
+from lib.fs import find_files, json_read, json_write
+
+
+def main():
+  for file in find_files("pathogen.json", here="data/"):
+    pathogen = json_read(file)
+
+    pathogen = dict_rename_many(
+      pathogen, {
+        "defaultGene": "defaultCds",
+        "geneOrderPreference": "cdsOrderPreference"
+      }
+    )
+
+    json_write(pathogen, file, no_sort_keys=True)
+
+
+if __name__ == '__main__':
+  main()

--- a/scripts/migrate_002_default_gene.py
+++ b/scripts/migrate_002_default_gene.py
@@ -2,17 +2,19 @@ from lib.container import dict_rename_many
 from lib.fs import find_files, json_read, json_write
 
 
+def rename_default_gene(pathogen):
+  return dict_rename_many(
+    pathogen, {
+      "defaultGene": "defaultCds",
+      "geneOrderPreference": "cdsOrderPreference"
+    }
+  )
+
+
 def main():
   for file in find_files("pathogen.json", here="data/"):
     pathogen = json_read(file)
-
-    pathogen = dict_rename_many(
-      pathogen, {
-        "defaultGene": "defaultCds",
-        "geneOrderPreference": "cdsOrderPreference"
-      }
-    )
-
+    pathogen = rename_default_gene(pathogen)
     json_write(pathogen, file, no_sort_keys=True)
 
 


### PR DESCRIPTION
Sibling PR in software: https://github.com/nextstrain/nextclade/pull/1329

The 2 PRs need to be merged simultaneously!

Modifies `pathogen.json`:

`defaultGene` -> `defaultCds`
`geneOrderPreference` -> `cdsOrderPreference`

The script `scripts/migrate_002_default_gene.py` facilitates migration of all datasets in the `data/` directory.

These changes affect software (see linked PR), existing datasets (including the ones not in the repo), all branches and PRs, dataset generation workflows, conversion from v2 to v3.

- [ ] Run `python3 scripts/migrate_002_default_gene.py` to modify current datasets
- [ ] Modify upstream dataset pipelines, templates and scripts
- [ ] Modify all branches and PRs
- [ ] Modify docs if applicable
- [ ] Merge this PR and PR in software simultaneously
