### PR TITLE
feat: apply rename defaultGene and geneOrderPreference from #115

### DIFF
--- a/data/nextstrain/flu/h1n1pdm/ha/CY121680/pathogen.json
+++ b/data/nextstrain/flu/h1n1pdm/ha/CY121680/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data/nextstrain/flu/h1n1pdm/ha/MW626062/pathogen.json
+++ b/data/nextstrain/flu/h1n1pdm/ha/MW626062/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data/nextstrain/flu/h1n1pdm/mp/pathogen.json
+++ b/data/nextstrain/flu/h1n1pdm/mp/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026431",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "M2",
+  "defaultCds": "M2",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h1n1pdm/na/MW626056/pathogen.json
+++ b/data/nextstrain/flu/h1n1pdm/na/MW626056/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "NA",
+  "defaultCds": "NA",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "NA"
   ],
   "maintenance": {

--- a/data/nextstrain/flu/h1n1pdm/np/pathogen.json
+++ b/data/nextstrain/flu/h1n1pdm/np/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026436",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "NP",
+  "defaultCds": "NP",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h1n1pdm/ns/pathogen.json
+++ b/data/nextstrain/flu/h1n1pdm/ns/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026432",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "NS1",
+  "defaultCds": "NS1",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h1n1pdm/pa/pathogen.json
+++ b/data/nextstrain/flu/h1n1pdm/pa/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026437",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "PA",
+  "defaultCds": "PA",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h1n1pdm/pb1/pathogen.json
+++ b/data/nextstrain/flu/h1n1pdm/pb1/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026435",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "PB1",
+  "defaultCds": "PB1",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h1n1pdm/pb2/pathogen.json
+++ b/data/nextstrain/flu/h1n1pdm/pb2/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026438",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "PB2",
+  "defaultCds": "PB2",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h3n2/ha/CY163680/pathogen.json
+++ b/data/nextstrain/flu/h3n2/ha/CY163680/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data/nextstrain/flu/h3n2/ha/EPI1857216/pathogen.json
+++ b/data/nextstrain/flu/h3n2/ha/EPI1857216/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data/nextstrain/flu/h3n2/mp/pathogen.json
+++ b/data/nextstrain/flu/h3n2/mp/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007367",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "M2",
+  "defaultCds": "M2",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h3n2/na/EPI1857215/pathogen.json
+++ b/data/nextstrain/flu/h3n2/na/EPI1857215/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "NA",
+  "defaultCds": "NA",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "NA"
   ],
   "maintenance": {

--- a/data/nextstrain/flu/h3n2/np/pathogen.json
+++ b/data/nextstrain/flu/h3n2/np/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007369",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "NP",
+  "defaultCds": "NP",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h3n2/ns/pathogen.json
+++ b/data/nextstrain/flu/h3n2/ns/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007370",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "NS1",
+  "defaultCds": "NS1",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h3n2/pa/pathogen.json
+++ b/data/nextstrain/flu/h3n2/pa/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007371",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "PA",
+  "defaultCds": "PA",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h3n2/pb1/pathogen.json
+++ b/data/nextstrain/flu/h3n2/pb1/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007372",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "PB1",
+  "defaultCds": "PB1",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/h3n2/pb2/pathogen.json
+++ b/data/nextstrain/flu/h3n2/pb2/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007373",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "PB2",
+  "defaultCds": "PB2",
   "version": {
     "tag": "unreleased"
   }

--- a/data/nextstrain/flu/vic/ha/KX058884/pathogen.json
+++ b/data/nextstrain/flu/vic/ha/KX058884/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data/nextstrain/flu/vic/na/CY073894/pathogen.json
+++ b/data/nextstrain/flu/vic/na/CY073894/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "NA",
+  "defaultCds": "NA",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "NA"
   ],
   "maintenance": {

--- a/data/nextstrain/flu/yam/ha/JN993010/pathogen.json
+++ b/data/nextstrain/flu/yam/ha/JN993010/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data/nextstrain/rsv/a/EPI_ISL_412866/pathogen.json
+++ b/data/nextstrain/rsv/a/EPI_ISL_412866/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "F",
+  "defaultCds": "F",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "F",
     "G",
     "L"

--- a/data/nextstrain/rsv/b/EPI_ISL_1653999/pathogen.json
+++ b/data/nextstrain/rsv/b/EPI_ISL_1653999/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "F",
+  "defaultCds": "F",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "F",
     "G",
     "L"

--- a/data/nextstrain/sars-cov-2/BA.2/pathogen.json
+++ b/data/nextstrain/sars-cov-2/BA.2/pathogen.json
@@ -14,7 +14,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "S",
+  "defaultCds": "S",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -24,7 +24,7 @@
     "reference": "reference.fasta",
     "treeJson": "tree.json"
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "S",
     "E",
     "M",

--- a/data/nextstrain/sars-cov-2/MN908947/pathogen.json
+++ b/data/nextstrain/sars-cov-2/MN908947/pathogen.json
@@ -14,7 +14,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "S",
+  "defaultCds": "S",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -24,7 +24,7 @@
     "reference": "reference.fasta",
     "treeJson": "tree.json"
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "S",
     "ORF1a",
     "ORF1b",

--- a/data_output/nextstrain/flu/h1n1pdm/ha/CY121680/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h1n1pdm/ha/CY121680/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data_output/nextstrain/flu/h1n1pdm/ha/MW626062/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h1n1pdm/ha/MW626062/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data_output/nextstrain/flu/h1n1pdm/mp/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h1n1pdm/mp/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026431",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "M2",
+  "defaultCds": "M2",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h1n1pdm/na/MW626056/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h1n1pdm/na/MW626056/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "NA",
+  "defaultCds": "NA",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "NA"
   ],
   "maintenance": {

--- a/data_output/nextstrain/flu/h1n1pdm/np/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h1n1pdm/np/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026436",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "NP",
+  "defaultCds": "NP",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h1n1pdm/ns/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h1n1pdm/ns/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026432",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "NS1",
+  "defaultCds": "NS1",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h1n1pdm/pa/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h1n1pdm/pa/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026437",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "PA",
+  "defaultCds": "PA",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h1n1pdm/pb1/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h1n1pdm/pb1/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026435",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "PB1",
+  "defaultCds": "PB1",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h1n1pdm/pb2/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h1n1pdm/pb2/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_026438",
     "reference name": "A/California/07/2009"
   },
-  "defaultGene": "PB2",
+  "defaultCds": "PB2",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h3n2/ha/CY163680/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h3n2/ha/CY163680/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data_output/nextstrain/flu/h3n2/ha/EPI1857216/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h3n2/ha/EPI1857216/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data_output/nextstrain/flu/h3n2/mp/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h3n2/mp/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007367",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "M2",
+  "defaultCds": "M2",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h3n2/na/EPI1857215/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h3n2/na/EPI1857215/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "NA",
+  "defaultCds": "NA",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "NA"
   ],
   "maintenance": {

--- a/data_output/nextstrain/flu/h3n2/np/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h3n2/np/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007369",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "NP",
+  "defaultCds": "NP",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h3n2/ns/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h3n2/ns/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007370",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "NS1",
+  "defaultCds": "NS1",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h3n2/pa/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h3n2/pa/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007371",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "PA",
+  "defaultCds": "PA",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h3n2/pb1/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h3n2/pb1/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007372",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "PB1",
+  "defaultCds": "PB1",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/h3n2/pb2/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/h3n2/pb2/unreleased/pathogen.json
@@ -42,7 +42,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [],
+  "cdsOrderPreference": [],
   "maintenance": {
     "website": [
       "https://nextstrain.org",
@@ -70,7 +70,7 @@
     "reference accession": "NC_007373",
     "reference name": "A/NewYork/392/2004"
   },
-  "defaultGene": "PB2",
+  "defaultCds": "PB2",
   "version": {
     "tag": "unreleased"
   }

--- a/data_output/nextstrain/flu/vic/ha/KX058884/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/vic/ha/KX058884/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data_output/nextstrain/flu/vic/na/CY073894/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/vic/na/CY073894/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "NA",
+  "defaultCds": "NA",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "NA"
   ],
   "maintenance": {

--- a/data_output/nextstrain/flu/yam/ha/JN993010/unreleased/pathogen.json
+++ b/data_output/nextstrain/flu/yam/ha/JN993010/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "HA1",
+  "defaultCds": "HA1",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "HA1",
     "HA2"
   ],

--- a/data_output/nextstrain/rsv/a/EPI_ISL_412866/unreleased/pathogen.json
+++ b/data_output/nextstrain/rsv/a/EPI_ISL_412866/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "F",
+  "defaultCds": "F",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "F",
     "G",
     "L"

--- a/data_output/nextstrain/rsv/b/EPI_ISL_1653999/unreleased/pathogen.json
+++ b/data_output/nextstrain/rsv/b/EPI_ISL_1653999/unreleased/pathogen.json
@@ -11,7 +11,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "F",
+  "defaultCds": "F",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -53,7 +53,7 @@
       "ignoredStopCodons": []
     }
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "F",
     "G",
     "L"

--- a/data_output/nextstrain/sars-cov-2/BA.2/unreleased/pathogen.json
+++ b/data_output/nextstrain/sars-cov-2/BA.2/unreleased/pathogen.json
@@ -14,7 +14,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "S",
+  "defaultCds": "S",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -24,7 +24,7 @@
     "reference": "reference.fasta",
     "treeJson": "tree.json"
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "S",
     "E",
     "M",

--- a/data_output/nextstrain/sars-cov-2/MN908947/unreleased/pathogen.json
+++ b/data_output/nextstrain/sars-cov-2/MN908947/unreleased/pathogen.json
@@ -14,7 +14,7 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "defaultGene": "S",
+  "defaultCds": "S",
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -24,7 +24,7 @@
     "reference": "reference.fasta",
     "treeJson": "tree.json"
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "S",
     "ORF1a",
     "ORF1b",


### PR DESCRIPTION
Followup of #115

Migrates existing datasets to the new field names

