### PR TITLE
fix: use tag rather than timestamp in dataset changelog headings

### DIFF
--- a/scripts/lib/changelog.py
+++ b/scripts/lib/changelog.py
@@ -2,7 +2,7 @@ from .container import dict_get_required, dict_get
 from .fs import file_read, file_write
 
 
-def changelog_prepare(dataset, updated_at, changelog_path):
+def changelog_prepare(dataset, tag, changelog_path):
   path = dict_get(dataset, ["path"])
   name = dict_get(dataset, ["attributes", "name"])
   release_notes = changelog_get_unreleased_section(changelog_path)
@@ -11,7 +11,7 @@ def changelog_prepare(dataset, updated_at, changelog_path):
       f"Cannot release dataset '{path}' without changelog. Please modify file '{changelog_path}': add '## Unreleased' section and briefly summarize the changes being released"
     )
 
-  full_changelog = file_read(changelog_path).replace(f"## Unreleased", f"## {updated_at}")
+  full_changelog = file_read(changelog_path).replace(f"## Unreleased", f"## {tag}")
   file_write(full_changelog, changelog_path)
 
   # attr_table = format_dataset_attributes_md_table(dict_get_required(dataset, ["attributes"]))

--- a/scripts/rebuild
+++ b/scripts/rebuild
@@ -394,7 +394,7 @@ def prepare_dataset_release_infos(args, datasets, datasets_from_index_json, coll
     if args.release:
       _, last_version = dataset_get_versions(dataset_from_index)
       release_info = prepare_dataset_release_info(
-        dataset_dir, dataset_from_index, dict_get(last_version, ["tag"]), updated_at
+        dataset_dir, dataset_from_index, dict_get(last_version, ["tag"]), tag
       )
       if release_info is None:
         continue
@@ -450,7 +450,7 @@ def publish_to_github_releases(args, tag, commit_hash, release_notes):
   )
 
 
-def prepare_dataset_release_info(dataset_dir, dataset, last_version, updated_at):
+def prepare_dataset_release_info(dataset_dir, dataset, last_version, tag):
   # modified_files = list(git_get_modified_files(from_revision=last_version, dirs=dataset_dir))
   # modified_files = list(map(lambda f: realpath(f), modified_files))
 
@@ -468,7 +468,7 @@ def prepare_dataset_release_info(dataset_dir, dataset, last_version, updated_at)
   #     f"Unreleased' section and briefly summarize the changes being released"
   #   )
 
-  release_notes = changelog_prepare(dataset, updated_at, changelog_path)
+  release_notes = changelog_prepare(dataset, tag, changelog_path)
 
   return {"dataset": dataset, "release_notes": release_notes, "dataset_dir": dataset_dir}
 


### PR DESCRIPTION
Rather than using a timestamp in changelog headings, e.g. `2024-02-16T04:00:32Z`, let's use version tag, which is a safe representation of a timestamp, e.g. `2024-02-16--04-00-32Z`.

Side-by-side for comparison:
```
2024-02-16T04:00:32Z
2024-02-16--04-00-32Z
```

This will make the representation consistent across `CHANGELOG.md`, `index.json`, `pathogen.json`, git commit text andgit  tags, filesystem paths, CLI display and args, etc.

Notable exception is web UI, which decides  how to represent dates in on its own to make it look friendlier for less technical users.

