### PR TITLE
fix: version tags in released zip archives

### DIFF
--- a/scripts/rebuild
+++ b/scripts/rebuild
@@ -491,11 +491,11 @@ def create_dataset_package(args, dataset, path, tag, dataset_dir):
     else:
       copy(inpath, outpath)
 
-  zip_basename = join(out_dir, "dataset")
-  make_zip(dataset_dir, zip_basename)
-
   path_safe = path.replace("/", "__")
-  copy(f"{zip_basename}.zip", join(args.temp_dir, f"{path_safe}__{tag}.zip"))
+  zip_basename = join(args.temp_dir, f"{path_safe}__{tag}")
+  make_zip(out_dir, zip_basename)
+
+  copy(f"{zip_basename}.zip", join(out_dir, f"dataset.zip"))
 
   not_found_json = {"status": 404, "message": "Not found"}
   json_write(not_found_json, join(args.output_dir, "404.json"))


### PR DESCRIPTION
Partially addresses https://github.com/nextstrain/nextclade_data/issues/175

Zip archives created during dataset rebuild contained unprocesed dataset files from `data/` directory. This resulted in `pathogen.json` containing versions with`"tag": "unreleased"`. The dataset files were valid, but the version tag basically missing.

Here we take the processed files instead, containing correct version tags.

