### PR TITLE
chore: ensure reproducible zip archives

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 biopython
 numpy
+repro-zipfile

--- a/scripts/lib/fs.py
+++ b/scripts/lib/fs.py
@@ -4,8 +4,9 @@ import json
 import os
 import shutil
 from os import walk, listdir, makedirs
-from os.path import dirname, join, abspath, isdir, isfile, islink
+from os.path import dirname, join, abspath, isdir, isfile, islink, relpath
 from typing import List
+from repro_zipfile import ReproducibleZipFile
 
 
 def find_files(pattern, here):
@@ -75,9 +76,11 @@ def ensure_dir(file_path):
   mkdir(dir_path)
 
 
-def make_zip(input_dir, out_zip):
-  shutil.make_archive(
-    base_name=out_zip,
-    format='zip',
-    root_dir=input_dir,
-  )
+def make_zip(input_dir: str, output_zip: str):
+  with ReproducibleZipFile(output_zip, "w") as z:
+    for root, dirs, files in os.walk(input_dir):
+      for file in files:
+        if not file.endswith(".zip"):
+          filepath = join(root, file)
+          arcpath = relpath(filepath, input_dir)
+          z.write(filepath, arcpath)

--- a/scripts/rebuild
+++ b/scripts/rebuild
@@ -492,10 +492,10 @@ def create_dataset_package(args, dataset, path, tag, dataset_dir):
       copy(inpath, outpath)
 
   path_safe = path.replace("/", "__")
-  zip_basename = join(args.temp_dir, f"{path_safe}__{tag}")
-  make_zip(out_dir, zip_basename)
+  zip_filename = join(args.temp_dir, f"{path_safe}__{tag}.zip")
+  make_zip(out_dir, zip_filename)
 
-  copy(f"{zip_basename}.zip", join(out_dir, f"dataset.zip"))
+  copy(f"{zip_filename}", join(out_dir, f"dataset.zip"))
 
   not_found_json = {"status": 404, "message": "Not found"}
   json_write(not_found_json, join(args.output_dir, "404.json"))


### PR DESCRIPTION
Every time zip archive is created it can have different contents even if all files are the same. This is due to file modification dates and permissions.

Let's use `repro_zipfile` package to create reproducible zip archives, which only depend on the input files.

This allows to avoid awkward situations when dataset rebuilds of the same dataset content  generates different outputs, non-empty git diffs and divergence of master, staging and release branches following a release.

See also: https://github.com/drivendataorg/repro-zipfile

