### PR TITLE
docs: add tree to file list

### DIFF
--- a/docs/dataset-creation-guide.md
+++ b/docs/dataset-creation-guide.md
@@ -117,7 +117,8 @@ Lastly, one can enable basic quality control for frame shifts, stop codons, miss
     "genomeAnnotation": "genome_annotation.gff3",
     "examples": "sequences.fasta",
     "readme": "README.md",
-    "changelog": "CHANGELOG.md"
+    "changelog": "CHANGELOG.md",
+    "treeJson": "tree.json"
   },
   "attributes": {
     "name": "Zika virus",


### PR DESCRIPTION
Minor edit to the pathogen.json file so that Nextclade Web can find the "tree.json" file. The Nextclade CLI call still works as expected.

Since the final augur tree might not be called "tree.json" could also add instructions to the user to modify the file name.