### PR TITLE
Updated private mutation QC metrics

### DIFF
--- a/data/community/moncla-lab/iav-h5/ha/2.3.4.4/CHANGELOG.md
+++ b/data/community/moncla-lab/iav-h5/ha/2.3.4.4/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+Updated private mutation QC metrics such that the typical value is the median value and the cutoff is the 97.5th percentile of private mutation counts assigned to unique GISAID sequences.
+
 ## 2024-11-19T14:18:53Z
 
 Updated tree.json to add mutation calling relative to A/American_wigeon/North_Carolina/AH0182517/2022

--- a/data/community/moncla-lab/iav-h5/ha/2.3.4.4/pathogen.json
+++ b/data/community/moncla-lab/iav-h5/ha/2.3.4.4/pathogen.json
@@ -47,7 +47,7 @@
       "mixedSitesThreshold": 4
     },
     "privateMutations": {
-      "cutoff": 30,
+      "cutoff": 18,
       "enabled": true,
       "typical": 6
     },

--- a/data/community/moncla-lab/iav-h5/ha/all-clades/CHANGELOG.md
+++ b/data/community/moncla-lab/iav-h5/ha/all-clades/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+Updated private mutation QC metrics such that the typical value is the median value and the cutoff is the 97.5th percentile of private mutation counts assigned to unique GISAID sequences.
+
 ## 2024-05-08T11:39:52Z
 
 Initial release for Nextclade v3!

--- a/data/community/moncla-lab/iav-h5/ha/all-clades/pathogen.json
+++ b/data/community/moncla-lab/iav-h5/ha/all-clades/pathogen.json
@@ -47,9 +47,9 @@
       "mixedSitesThreshold": 4
     },
     "privateMutations": {
-      "cutoff": 95,
+      "cutoff": 97,
       "enabled": true,
-      "typical": 19
+      "typical": 24
     },
     "snpClusters": {
       "clusterCutOff": 5,


### PR DESCRIPTION
Based on analysis of unique GISAID sequences, slightly adjusted private mutation QC metrics. Now, the typical value is set to the median value and the cutoff is set to the 97.5th percentile of private mutation counts of GISAID sequences.