### PR TITLE
chore: add reviewers to the sc2 autoupdate prs [skip ci]

### DIFF
--- a/scripts/update_sc2_datasets
+++ b/scripts/update_sc2_datasets
@@ -126,7 +126,9 @@ function submit_pr() {
   pr_body | gh pr create \
     --title "${TITLE}" \
     --body-file - \
-    --repo "nextstrain/nextclade_data"
+    --repo "nextstrain/nextclade_data" \
+    --reviewer "corneliusroemer" \
+    --reviewer "rneher"
 }
 
 # Get PR number from the dataset_name of gh command


### PR DESCRIPTION
See: https://github.com/nextstrain/nextclade_data/pull/255

Automatically add reviewers to the automated SC2 datasets update PRs submitted by the bot weekly. This is to encourage review and merging.

If you are disagree with this, feel free to remove yourself or revert this PR.

