### PR TITLE
feat: exclude deprecated datasets from suggestions

### DIFF
--- a/scripts/rebuild
+++ b/scripts/rebuild
@@ -394,7 +394,9 @@ def process_one_collection(collection_json_path, index_json, args, tag, updated_
     try:
       dataset, ref = index_one_dataset(args, pathogen_json_path, dataset_from_index, tag, updated_at)
       datasets.append(dataset)
-      refs.update({dataset["path"]: ref})
+      # exclude deprecated datasets from list of refs that is later used to build minimizer index
+      if not dataset['attributes'].get('deprecated', False):
+        refs.update({dataset["path"]: ref})
     except Exception as e:
       raise ValueError(f"When processing '{pathogen_json_path}'") from e
 


### PR DESCRIPTION
When analyzing slightly unusual SC2 sequences, it can happen that they are closer to XBB or other references of depreacted SC2 sequences. if these are autosuggested and the user doesn't pay attention, they get unexpected and sub-par results. In the future we could include an additional attribute `exclude-from-index`.

