### PR TITLE
fix: schema version must be 3.0.0  for nextclade v3 datasets

### DIFF
--- a/data/nextstrain/measles/N450/WHO-2012/CHANGELOG.md
+++ b/data/nextstrain/measles/N450/WHO-2012/CHANGELOG.md
@@ -1,7 +1,12 @@
+## Unreleased
+
+Fix `schemaVersion` field in `pathogen.json`.
+
+This is a technical change. Data is unchanged.
+
 ## 2025-03-26T11:47:13Z
 
 Fix GFF3 format issues in genome annotation
-
 
 ## 2024-06-07T06:48:19Z
 

--- a/data/nextstrain/measles/N450/WHO-2012/pathogen.json
+++ b/data/nextstrain/measles/N450/WHO-2012/pathogen.json
@@ -13,7 +13,7 @@
     "reference name": "Ichinose-B95a",
     "reference accession": "NC_001498.1"
   },
-  "schemaVersion": "1.0.0",
+  "schemaVersion": "3.0.0",
   "alignmentParams": {
       "minSeedCover": 0.01,
       "minLength": 400


### PR DESCRIPTION
Resolves https://github.com/nextstrain/nextclade_data/issues/321

