### PR TITLE
fix(ci): more informative warnings if tree root and ref seq mismatch

### DIFF
--- a/scripts/rebuild
+++ b/scripts/rebuild
@@ -167,26 +167,29 @@ def get_ref_seq(pathogen_json, dataset_dir):
     raise ValueError(f"When reading reference sequence") from e
 
 
-def check_ref_seq_mismatch(path, standalone_ref, pathogen_json, dataset_dir):
+def check_ref_seq_mismatch(path, standalone_ref, pathogen_json, dataset_dir) -> None:
   tree_filename = dict_get(pathogen_json, ["files", "treeJson"])
   tree_json_path = join(dataset_dir, tree_filename) if tree_filename else None
   if tree_json_path is not None and isfile(tree_json_path):
     tree_json = json_read(tree_json_path)
     tree_ref = dict_get(tree_json, ["root_sequence", "nuc"])
     if tree_ref is not None:
-      if standalone_ref.seq != tree_ref:
+      alignment_ref = standalone_ref.seq.upper()
+      tree_root = tree_ref.upper()
+
+      if alignment_ref != tree_root:
         shared_log_prefix = (
           f"{path}: Reference sequence provided does not exactly match reference (root) sequence in Auspice JSON. "
           "This warning signals that there is a potential for failures if the mismatch is not intended."
         )
-        if len(standalone_ref.seq) != len(tree_ref):
+        if len(alignment_ref) != len(tree_root):
           l.warning(
-            f"{shared_log_prefix} Reference sequence length: {len(standalone_ref.seq)}, Auspice JSON root sequence length: {len(tree_ref)}"
+            f"{shared_log_prefix} Reference sequence length: {len(alignment_ref)}, Auspice JSON root sequence length: {len(tree_root)}"
           )
           return
 
         mismatches = []
-        for i, (a, b) in enumerate(zip(standalone_ref.seq, tree_ref), start=1):
+        for i, (a, b) in enumerate(zip(alignment_ref, tree_root), start=1):
           if a != b:
             mismatches.append(f"{a}{i}{b}")
         l.warning(


### PR DESCRIPTION
Resolves #354 (false positive)

I've added more informative logging to the warning for mismatched ref. Motivated by #354

Turns out that the check was sensitive to upper/lower case mismatch - which we're also fixing here in this PR as Nextclade is case insensitive.

```
$ ./scripts/rebuild --input-dir 'data/' --output-dir 'data_output/' --no-pull
WARNING: :nextstrain/mumps/sh: Reference sequence provided does not exactly match reference (root) sequence in Auspice JSON. This warning signals that there is a potential for failures if the mismatch is not intended. Mismatches (refbase>pos>treerootbase): t1T, t2T, a3A, a4A, a5A, a6A, a7A, a8A, g9G, g10G, t11T, t12T, t13T, a14A, g15G, a16A, a17A, a18A, a19A, a20A, a21A, a22A, c23C, t24T, a25A, a26A, a27A, a28A, t29T, a30A, a31A, g32G, a33A, a34A, t35T, g36G, a37A, a38A, t39T, c40C, t41T, c42C, c43C, t44T, a45A, g46G, g47G, g48G, t49T, c50C, g51G, t52T, a53A, a54A, c55C, g56G, t57T, c58C, t59T, c60C, g61G, t62T, g63G, a64A, c65C, c66C, c67C, t68T, g69G, c70C, c71C, g72G, t73T, t74T, g75G, c76C, a77A, c78C, t79T, a80A, t81T, g82G, c83C, c84C, g85G, g86G, c87C, a88A, a89A, t90T, c91C, c92C, a93A, a94A, c95C, c96C, t97T, c98C, c99C, c100C, t101T, t102T, a103A, t104T, a105A, c106C, c107C, t108T, a109A, a110A, c111C, a112A, t113T, t114T, t115T, c116C, t117T, a118A, t119T, t120T, g121G, c122C, t123T, a124A, a125A, c126C, c127C, c128C, t129T, t130T, c131C, t132T, c133C, t134T, a135A, t136T, c137C, t138T, a139A, a140A, t141T, c142C, a143A, t144T, a145A, a146A, c147C, t148T, c149C, t150T, g151G, t152T, a153A, t154T, g155G, t156T, c157C, t158T, g159G, g160G, a161A, c162C, t163T, a164A, t165T, a166A, t167T, t168T, g169G, a170A, c171C, c172C, a173A, t174T, t175T, a176A, a177A, c178C, c179C, a180A, t181T, a182A, a183A, t184T, a185A, c186C, g187G, g188G, c189C, g190G, g191G, t192T, t193T, c194C, g195G, g196G, t197T, a198A, t199T, g200G, c201C, a202A, g203G, c204C, a205A, c206C, t207T, g208G, t209T, a210A, c211C, c212C, a213A, g214G, c215C, g216G, a217A, t218T, c219C, c220C, t221T, t222T, c223C, t224T, c225C, t226T, c227C, g228G, c229C, t230T, g231G, g232G, g233G, g234G, t235T, t236T, t237T, t238T, g239G, a240A, t241T, c242C, a243A, a244A, t245T, c246C, a247A, c248C, t249T, c250C, t251T, a252A, g253G, a254A, a255A, a256A, g257G, a258A, t259T, c260C, c261C, t262T, c263C, a264A, g265G, t266T, t267T, a268A, g269G, g270G, g271G, c272C, a273A, a274A, g275G, t276T, c277C, c278C, c279C, g280G, a281A, t282T, c283C, c284C, g285G, t286T, c287C, a288A, c289C, g290G, c291C, t292T, a293A, g294G, a295A, a296A, c297C, a298A, a299A, g300G, c301C, t302T, g303G, c304C, a305A, t306T, c307C, c308C, a309A, a310A, a311A, t312T, g313G, a314A, a315A, g316G, c317C, t318T, g319G, c320C, a321A, c322C, t323T, a324A, c325C, c326C, a327A, t328T, g329G, a330A, g331G, a332A, c333C, a334A, t335T, a336A, a337A, a338A, g339G, a340A, a341A, a342A, a343A, a344A, a345A, g346G, c347C, a348A, a349A, g350G, c351C, c352C, a353A, g354G, a355A, a356A, c357C, a358A, a359A, a360A, c361C
```

Why do we warn instead of error? IIUC, if there's a real mismatch, Nextclade would crash or error at the very least. The warning doesn't seem to actually be looked at by anyone regularly so it's like it didn't exist. Better error loudly.