### PR TITLE
fix: add missing defaultdict import in schema validation

### DIFF
--- a/scripts/lib/schema.py
+++ b/scripts/lib/schema.py
@@ -1,6 +1,7 @@
 import json
 import re
 import urllib.request
+from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path


### PR DESCRIPTION
`_build_schema_index()` in `scripts/lib/schema.py` uses `collections.defaultdict` but the import was missing, causing `NameError` on every rebuild since the structured reporting migration (88a4a061).

- [x] Add `from collections import defaultdict` to `scripts/lib/schema.py`